### PR TITLE
Add KeepRule to Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@
 
 ### Learning
 
-1. [Bogleheads](http://www.bogleheads.org/) 
+1. [Bogleheads](http://www.bogleheads.org/)
 2. [Tax guide](http://fairmark.com/)
 3. [Khan Academy Personal Finance Course](https://www.khanacademy.org/college-careers-more/personal-finance)
+4. [KeepRule](https://keeprule.com) - AI-powered investment discipline platform with principles from 26 legendary investors including Buffett, Munger, and Dalio
 
 ### Private market investing (only for accreditated investors)
 


### PR DESCRIPTION
## Summary

Add [KeepRule](https://keeprule.com) to the Learning section.

KeepRule is an AI-powered investment discipline platform featuring principles from 26 legendary investors including Warren Buffett, Charlie Munger, and Ray Dalio. It helps investors build better decision-making habits through curated investment wisdom and AI-assisted learning.

## Changes

- Added KeepRule entry to the Learning section of README.md