### PR TITLE
Add The Quiet-Broke Index under new Cost of Living section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@
 1. [RealtyShares](https://www.realtyshares.com)
 2. [AlphaFlow](https://www.alphaflow.com)
 3. [Fund Rise](https://fundrise.com/)
+
+### Cost of Living
+
+1. [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite ranking of how much of a $400K household income gets consumed by housing, taxes, childcare, healthcare, and transport. Open methodology, free, no email gate.


### PR DESCRIPTION
## What is this?

**[The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/)** is a free composite ranking of 30 US metros showing what percentage of a $400K household income gets consumed by five unavoidable cost categories: housing, taxes, childcare, healthcare, and transportation.

## Why it fits

The list currently covers investment tools, money management, and real estate — but doesn't have a section for cost-of-living comparisons, which are highly relevant for personal financial planning (relocation decisions, salary negotiations, understanding real purchasing power).

- Free and ungated — no email, no paywall
- [Open methodology](https://jeevesagency.github.io/quiet-broke-index/methodology.html) — all sources documented (Census ACS, BLS CES, HUD Fair Market Rents, Tax Foundation)
- Helps with a core personal finance question: which city actually lets you keep more of your income?

## Entry added

Added a new **Cost of Living** section:

```markdown
### Cost of Living

1. [The Quiet-Broke Index](https://jeevesagency.github.io/quiet-broke-index/) - A 30-metro composite ranking of how much of a $400K household income gets consumed by housing, taxes, childcare, healthcare, and transport. Open methodology, free, no email gate.
```